### PR TITLE
[DM-23286] Update nginx TLS configuration settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM        nginx
 MAINTAINER  sqre-admin
 LABEL       description="SSL termination and proxy for SQuaRE microservices" \
             name="lsstsqre/k8s-api-nginx"
-ARG         VERSION="0.0.5"
+ARG         VERSION="0.0.6"
 LABEL       version="$VERSION"
 COPY        nginx.conf /
 COPY        entrypoint.sh /

--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ The `nginx.conf` file contains both TLS settings and proxy mappings.
 
 #### TLS Settings
 
-SSL settings are largely taken from [Strong SSL Security on
-nginx](https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
-"Strong SSL Security on nginx").
+The TLS settings are from the [Mozilla SSL Configuration Generator](https://ssl-config.mozilla.org/) using the intermediate settings option.
 
 #### Proxy Mappings
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -13,22 +13,22 @@ http {
 
   server {
     ssl on;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 24h;
+    ssl_session_cache shared:MozSSL:10m;
+    ssl_session_timeout 1d;
     ssl_buffer_size 1400;
     ssl_session_tickets off;
 
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
-    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:ECDHE-RSA-AES128-GCM-SHA256:AES256+EECDH:DHE-RSA-AES128-GCM-SHA256:AES256+EDH:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-SHA256:AES128-SHA256:AES256-SHA:AES128-SHA:DES-CBC3-SHA:HIGH:!aNULL:!eNULL:!EXPORT:!DES:!MD5:!PSK:!RC4";
-    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
 
     ssl_stapling on;
     ssl_stapling_verify on;
     resolver 8.8.4.4 8.8.8.8 valid=600s;
     resolver_timeout 10s;
 
-    add_header Strict-Transport-Security max-age=63072000;
+    add_header Strict-Transport-Security max-age=63072000 always;
     add_header X-Frame-Options DENY;
     add_header X-Content-Type-Options nosniff;
 


### PR DESCRIPTION
The previous settings received only a B grade from SSL Labs
because they allowed TLS 1.0 and TLS 1.1 and allowed some older
ciphers that are no longer considered secure.

The new settings are based on the Mozilla SSL Configuration
Generator, which is now the recommended resource for strong SSL
configuration, using the intermediate settings option.

Update README.md accordingly with a pointer to the configuration
generator.